### PR TITLE
Replace deprecated methods

### DIFF
--- a/includes/api.php
+++ b/includes/api.php
@@ -23,8 +23,8 @@ return [
             'id' => (string)$page->id(),
             ];
 
-            if ($page->hasVisibleChildren()) {
-            $children = $page->children()->visible();
+            if ($page->hasListedChildren()) {
+            $children = $page->children()->listed();
             $childrendata = [];
             foreach ($children as $child) {
                 $childrendata[] = [


### PR DESCRIPTION
Those two will cause warnings when in debug mode, starting in Kirby 3.3.0.
Best to switch to the v3 equivalents.